### PR TITLE
chore: add clank8y workflow

### DIFF
--- a/.github/workflows/clank8y.yml
+++ b/.github/workflows/clank8y.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run clank8y
-        uses: clank8y/clank8y@9c6ddcfcd4dddce84eea2f65b574017d5d4e8aa1
+        uses: clank8y/clank8y@c6fa3e77e1255792270a39c1a5ed331c2684df2b
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_CLANK8Y_TOKEN }}
         with:

--- a/.github/workflows/clank8y.yml
+++ b/.github/workflows/clank8y.yml
@@ -20,4 +20,4 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_CLANK8Y_TOKEN }}
         with:
           prompt: ${{ inputs.prompt }}
-          model: anthropic:claude-opus-4-7
+          model: anthropic:claude-sonnet-4-6

--- a/.github/workflows/clank8y.yml
+++ b/.github/workflows/clank8y.yml
@@ -1,0 +1,23 @@
+name: clank8y
+
+on:
+  workflow_dispatch:
+    inputs:
+      prompt:
+        type: string
+        required: false
+
+permissions:
+  id-token: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run clank8y
+        uses: clank8y/clank8y@9c6ddcfcd4dddce84eea2f65b574017d5d4e8aa1
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_CLANK8Y_TOKEN }}
+        with:
+          prompt: ${{ inputs.prompt }}
+          model: anthropic:claude-opus-4-7

--- a/clank8y.json
+++ b/clank8y.json
@@ -1,0 +1,3 @@
+{
+  "allowedClank8yTriggerers": ["jakob-c8y"]
+}


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow for clank8y
- configure the workflow to use the repository secret `ANTHROPIC_CLANK8Y_TOKEN`
- set the model to `anthropic:claude-opus-4-7`

## Notes
- workflow is pinned to a specific clank8y commit SHA
- clank8y must be installed as a GitHub App for the repo/org