### PR TITLE
chore: update clank8y to v1.4.2

### DIFF
--- a/.github/workflows/clank8y.yml
+++ b/.github/workflows/clank8y.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run clank8y
-        uses: clank8y/clank8y@c6fa3e77e1255792270a39c1a5ed331c2684df2b
+        uses: clank8y/clank8y@4730793198c7d36dffa286eefab8dbedd960c430
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_CLANK8Y_TOKEN }}
         with:

--- a/clank8y.json
+++ b/clank8y.json
@@ -1,3 +1,3 @@
 {
-  "allowedClank8yTriggerers": ["jakob-c8y"]
+  "allowedClank8yTriggerers": ["Cumulocity-IoT/ui-guild"]
 }


### PR DESCRIPTION
## Summary
- update the clank8y GitHub Action pin to v1.4.2
- allow the full `Cumulocity-IoT/ui-guild` team to trigger clank8y

## Testing
- not run (workflow/config-only change)