### PR TITLE
feat(shared): persist data grid column widths in grid config

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -40,6 +40,7 @@ export * from './services/active-tab.service';
 export * from './services/application-availability.service';
 export * from './services/data-grid-patch.service';
 export * from './services/dtm.service';
+export * from './services/grid-column-width.service';
 export * from './services/dom.service';
 export * from './services/hierarchy-aggregation.service';
 export * from './services/inventory-delta-polling.service';

--- a/packages/shared/src/services/grid-column-width.service.spec.ts
+++ b/packages/shared/src/services/grid-column-width.service.spec.ts
@@ -1,0 +1,318 @@
+import { TestBed } from '@angular/core/testing';
+import { DataGridComponent, DataGridService } from '@c8y/ngx-components';
+import { Column, ColumnConfig, GridConfig } from '@c8y/ngx-components';
+import { Subject, of } from 'rxjs';
+import { provideMock } from '../helpers/auto-mock.helper';
+import { ExtendedColumnConfig, GridColumnWidthService, isExtendedColumnConfig } from './grid-column-width.service';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeColumn(
+  name: string,
+  gridTrackSize: string,
+  positionFixed = false
+): Column {
+  return { name, gridTrackSize, positionFixed, visible: true } as Column;
+}
+
+function makeStoredConfig(columns: ColumnConfig[]): GridConfig {
+  return { columns, pagination: { pageSize: 25 } };
+}
+
+function makeGrid(columns: Column[] = [makeColumn('name', '200px'), makeColumn('type', '150px')]) {
+  let currentColumns = ([] as Column[]).concat(columns);
+  const configurationStrategy = {
+    getConfig$: jest.fn().mockReturnValue(of(makeStoredConfig([]))),
+    saveConfig$: jest.fn().mockReturnValue(of(undefined)),
+    getContext: jest.fn(),
+    isContextKnown: jest.fn().mockReturnValue(true),
+  };
+
+  const grid = {
+    get columns() { return currentColumns; },
+    set columns(val) { currentColumns = val; },
+    get pagination() { return { pageSize: 25 }; },
+    resizeHandleMouseDown$: new Subject<{ event: MouseEvent; targetColumnName: string }>(),
+    resizeHandleContainerMouseUp$: new Subject<MouseEvent>(),
+    configurationStrategy,
+  } as unknown as DataGridComponent;
+
+  return grid;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('GridColumnWidthService', () => {
+  let service: GridColumnWidthService;
+  let dataGridService: DataGridService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [GridColumnWidthService, provideMock(DataGridService)],
+    });
+
+    service = TestBed.inject(GridColumnWidthService);
+    dataGridService = TestBed.inject(DataGridService);
+
+    // Provide a no-op default for applyConfigToColumns.
+    jest.spyOn(dataGridService, 'applyConfigToColumns').mockImplementation((_, cols) => ([] as Column[]).concat(cols));
+  });
+
+  // -------------------------------------------------------------------------
+  // applyConfigToColumns patch (load/restore side)
+  // -------------------------------------------------------------------------
+
+  // -------------------------------------------------------------------------
+  // isExtendedColumnConfig type guard
+  // -------------------------------------------------------------------------
+
+  describe('isExtendedColumnConfig', () => {
+    it('returns true when gridTrackSize is a string', () => {
+      expect(isExtendedColumnConfig({ name: 'name', gridTrackSize: '200px' })).toBe(true);
+    });
+
+    it('returns false when gridTrackSize is absent', () => {
+      expect(isExtendedColumnConfig({ name: 'name', visible: true })).toBe(false);
+    });
+
+    it('returns false when gridTrackSize is not a string (e.g. number from malformed storage)', () => {
+      expect(isExtendedColumnConfig({ name: 'name', gridTrackSize: 200 as any })).toBe(false);
+    });
+  });
+
+  describe('patching DataGridService.applyConfigToColumns', () => {
+    it('restores gridTrackSize from an ExtendedColumnConfig onto the matching live column', () => {
+      const destroy$ = new Subject<void>();
+      const grid = makeGrid();
+      service.applyColumnWidthPersistence(grid, destroy$.asObservable());
+
+      const storedColumns: ExtendedColumnConfig[] = [
+        { name: 'name', visible: true, gridTrackSize: '350px' },
+        { name: 'type', visible: true, gridTrackSize: '280px' },
+      ];
+      const inputColumns = [makeColumn('name', '200px'), makeColumn('type', '150px')];
+
+      // Invoke the patched method directly.
+      const result = dataGridService.applyConfigToColumns(
+        makeStoredConfig(storedColumns),
+        inputColumns
+      );
+
+      expect(result.find((c) => c.name === 'name')?.gridTrackSize).toBe('350px');
+      expect(result.find((c) => c.name === 'type')?.gridTrackSize).toBe('280px');
+      destroy$.next();
+    });
+
+    it('leaves columns unchanged when the stored config has no gridTrackSize', () => {
+      const destroy$ = new Subject<void>();
+      const grid = makeGrid();
+      service.applyColumnWidthPersistence(grid, destroy$.asObservable());
+
+      const storedColumns: ColumnConfig[] = [
+        { name: 'name', visible: true },
+        { name: 'type', visible: true },
+      ];
+      const inputColumns = [makeColumn('name', '200px'), makeColumn('type', '150px')];
+
+      const result = dataGridService.applyConfigToColumns(
+        makeStoredConfig(storedColumns),
+        inputColumns
+      );
+
+      expect(result.find((c) => c.name === 'name')?.gridTrackSize).toBe('200px');
+      expect(result.find((c) => c.name === 'type')?.gridTrackSize).toBe('150px');
+      destroy$.next();
+    });
+
+    it('does not double-patch DataGridService across multiple grid instances', () => {
+      const d1$ = new Subject<void>();
+      const d2$ = new Subject<void>();
+
+      service.applyColumnWidthPersistence(makeGrid(), d1$.asObservable());
+      const patchedFn = dataGridService.applyConfigToColumns;
+
+      service.applyColumnWidthPersistence(makeGrid(), d2$.asObservable());
+
+      expect(dataGridService.applyConfigToColumns).toBe(patchedFn);
+      d1$.next(); d2$.next();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Resize save (save side)
+  // -------------------------------------------------------------------------
+
+  describe('saving widths after resize', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+      jest.spyOn(global, 'requestAnimationFrame').mockImplementation((cb) => { cb(0); return 0; });
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+      jest.restoreAllMocks();
+    });
+
+    function simulateResize(grid: DataGridComponent, finalColumns: Column[]) {
+      (grid.resizeHandleMouseDown$ as Subject<any>).next({ event: {} as MouseEvent, targetColumnName: finalColumns[0].name });
+      grid.columns = finalColumns;
+      (grid.resizeHandleContainerMouseUp$ as Subject<MouseEvent>).next({} as MouseEvent);
+      jest.runAllTimers();
+    }
+
+    it('loads the stored config, merges current widths, and saves via configurationStrategy', () => {
+      const grid = makeGrid();
+      const storedConfig = makeStoredConfig([
+        { name: 'name', visible: true },
+        { name: 'type', visible: true },
+      ]);
+      (grid.configurationStrategy.getConfig$ as jest.Mock).mockReturnValue(of(storedConfig));
+      const destroy$ = new Subject<void>();
+
+      service.applyColumnWidthPersistence(grid, destroy$.asObservable());
+
+      simulateResize(grid, [makeColumn('name', '380px'), makeColumn('type', '150px')]);
+
+      expect(grid.configurationStrategy.saveConfig$).toHaveBeenCalledWith(
+        expect.objectContaining({
+          columns: expect.arrayContaining([
+            expect.objectContaining({ name: 'name', gridTrackSize: '380px' }),
+            expect.objectContaining({ name: 'type', gridTrackSize: '150px' }),
+          ]),
+        })
+      );
+      destroy$.next();
+    });
+
+    it('preserves existing ColumnConfig fields (visible, sortOrder, filter) when merging widths', () => {
+      const grid = makeGrid();
+      const storedConfig = makeStoredConfig([
+        { name: 'name', visible: false, sortOrder: 'asc' },
+        { name: 'type', visible: true },
+      ]);
+      (grid.configurationStrategy.getConfig$ as jest.Mock).mockReturnValue(of(storedConfig));
+      const destroy$ = new Subject<void>();
+
+      service.applyColumnWidthPersistence(grid, destroy$.asObservable());
+      simulateResize(grid, [makeColumn('name', '300px'), makeColumn('type', '150px')]);
+
+      const savedConfig = (grid.configurationStrategy.saveConfig$ as jest.Mock).mock.calls[0][0] as GridConfig;
+      const nameCol = savedConfig.columns.find((c) => c.name === 'name') as ExtendedColumnConfig;
+
+      expect(nameCol.visible).toBe(false);
+      expect(nameCol.sortOrder).toBe('asc');
+      expect(nameCol.gridTrackSize).toBe('300px');
+      destroy$.next();
+    });
+
+    it('excludes positionFixed columns (checkbox, actions) from saved widths', () => {
+      const grid = makeGrid([
+        makeColumn('name', '200px'),
+        makeColumn('checkbox', '32px', /* positionFixed */ true),
+      ]);
+      const storedConfig = makeStoredConfig([{ name: 'name', visible: true }]);
+      (grid.configurationStrategy.getConfig$ as jest.Mock).mockReturnValue(of(storedConfig));
+      const destroy$ = new Subject<void>();
+
+      service.applyColumnWidthPersistence(grid, destroy$.asObservable());
+      simulateResize(grid, [
+        makeColumn('name', '400px'),
+        makeColumn('checkbox', '32px', true),
+      ]);
+
+      const savedConfig = (grid.configurationStrategy.saveConfig$ as jest.Mock).mock.calls[0][0] as GridConfig;
+      const checkboxCol = savedConfig.columns.find((c) => c.name === 'checkbox');
+      expect(checkboxCol).toBeUndefined(); // not in storedConfig.columns → not in merged output either
+      destroy$.next();
+    });
+
+    it('does NOT save when resizeHandleContainerMouseUp$ fires without a prior resizeHandleMouseDown$', () => {
+      const grid = makeGrid();
+      const destroy$ = new Subject<void>();
+
+      service.applyColumnWidthPersistence(grid, destroy$.asObservable());
+
+      (grid.resizeHandleContainerMouseUp$ as Subject<MouseEvent>).next({} as MouseEvent);
+      jest.runAllTimers();
+
+      expect(grid.configurationStrategy.saveConfig$).not.toHaveBeenCalled();
+      destroy$.next();
+    });
+
+    it('is a no-op when no configurationStrategy is provided', () => {
+      const grid = makeGrid();
+      (grid as any).configurationStrategy = undefined;
+
+      // Should not throw.
+      expect(() =>
+        service.applyColumnWidthPersistence(grid, new Subject<void>().asObservable())
+      ).not.toThrow();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Guard / error throwing for missing private API
+  // -------------------------------------------------------------------------
+
+  describe('throwing when expected private API is missing', () => {
+    it('throws when DataGridService.applyConfigToColumns is not found', () => {
+      delete (dataGridService as any).applyConfigToColumns;
+
+      expect(() =>
+        service.applyColumnWidthPersistence(makeGrid(), new Subject<void>().asObservable())
+      ).toThrow('DataGridService.applyConfigToColumns not found');
+    });
+
+    it('throws when DataGridComponent.resizeHandleMouseDown$ is not found', () => {
+      const grid = makeGrid();
+      delete (grid as any).resizeHandleMouseDown$;
+
+      expect(() =>
+        service.applyColumnWidthPersistence(grid, new Subject<void>().asObservable())
+      ).toThrow('DataGridComponent.resizeHandleMouseDown$ not found');
+    });
+
+    it('throws when DataGridComponent.resizeHandleContainerMouseUp$ is not found', () => {
+      const grid = makeGrid();
+      delete (grid as any).resizeHandleContainerMouseUp$;
+
+      expect(() =>
+        service.applyColumnWidthPersistence(grid, new Subject<void>().asObservable())
+      ).toThrow('DataGridComponent.resizeHandleContainerMouseUp$ not found');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Teardown
+  // -------------------------------------------------------------------------
+
+  describe('cleanup via until$', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+      jest.spyOn(global, 'requestAnimationFrame').mockImplementation((cb) => { cb(0); return 0; });
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+      jest.restoreAllMocks();
+    });
+
+    it('stops listening to resize events after until$ emits', () => {
+      const grid = makeGrid();
+      const destroy$ = new Subject<void>();
+
+      service.applyColumnWidthPersistence(grid, destroy$.asObservable());
+      destroy$.next();
+
+      (grid.resizeHandleMouseDown$ as Subject<any>).next({ event: {} as MouseEvent, targetColumnName: 'name' });
+      (grid.resizeHandleContainerMouseUp$ as Subject<MouseEvent>).next({} as MouseEvent);
+      jest.runAllTimers();
+
+      expect(grid.configurationStrategy.saveConfig$).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/shared/src/services/grid-column-width.service.spec.ts
+++ b/packages/shared/src/services/grid-column-width.service.spec.ts
@@ -3,18 +3,18 @@ import { DataGridComponent, DataGridService } from '@c8y/ngx-components';
 import { Column, ColumnConfig, GridConfig } from '@c8y/ngx-components';
 import { Subject, of } from 'rxjs';
 import { provideMock } from '../helpers/auto-mock.helper';
-import { ExtendedColumnConfig, GridColumnWidthService, isExtendedColumnConfig } from './grid-column-width.service';
+import {
+  ExtendedColumnConfig,
+  GridColumnWidthService,
+  isExtendedColumnConfig,
+} from './grid-column-width.service';
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-function makeColumn(
-  name: string,
-  gridTrackSize: string,
-  positionFixed = false
-): Column {
-  return { name, gridTrackSize, positionFixed, visible: true } as Column;
+function makeColumn(name: string, gridTrackSize: string, positionFixed = false): Column {
+  return { name, gridTrackSize, positionFixed, visible: true };
 }
 
 function makeStoredConfig(columns: ColumnConfig[]): GridConfig {
@@ -24,18 +24,24 @@ function makeStoredConfig(columns: ColumnConfig[]): GridConfig {
 function makeGrid(columns: Column[] = [makeColumn('name', '200px'), makeColumn('type', '150px')]) {
   let currentColumns = ([] as Column[]).concat(columns);
   const configurationStrategy = {
-    getConfig$: jest.fn().mockReturnValue(of(makeStoredConfig([]))),
-    saveConfig$: jest.fn().mockReturnValue(of(undefined)),
-    getContext: jest.fn(),
-    isContextKnown: jest.fn().mockReturnValue(true),
+    getConfig$: jasmine.createSpy('getConfig$').and.returnValue(of(makeStoredConfig([]))),
+    saveConfig$: jasmine.createSpy('saveConfig$').and.returnValue(of(undefined)),
+    getContext: jasmine.createSpy('getContext'),
+    isContextKnown: jasmine.createSpy('isContextKnown').and.returnValue(true),
   };
 
   const grid = {
-    get columns() { return currentColumns; },
-    set columns(val) { currentColumns = val; },
-    get pagination() { return { pageSize: 25 }; },
+    get columns() {
+      return currentColumns;
+    },
+    set columns(val) {
+      currentColumns = val;
+    },
+    get pagination() {
+      return { pageSize: 25 };
+    },
     resizeHandleMouseDown$: new Subject<{ event: MouseEvent; targetColumnName: string }>(),
-    resizeHandleContainerMouseUp$: new Subject<MouseEvent>(),
+    windowMouseUp$: new Subject<MouseEvent>(),
     configurationStrategy,
   } as unknown as DataGridComponent;
 
@@ -59,7 +65,9 @@ describe('GridColumnWidthService', () => {
     dataGridService = TestBed.inject(DataGridService);
 
     // Provide a no-op default for applyConfigToColumns.
-    jest.spyOn(dataGridService, 'applyConfigToColumns').mockImplementation((_, cols) => ([] as Column[]).concat(cols));
+    (dataGridService.applyConfigToColumns as jasmine.Spy).and.callFake((_, cols: Column[]) =>
+      ([] as Column[]).concat(cols)
+    );
   });
 
   // -------------------------------------------------------------------------
@@ -72,7 +80,9 @@ describe('GridColumnWidthService', () => {
 
   describe('isExtendedColumnConfig', () => {
     it('returns true when gridTrackSize is a string', () => {
-      expect(isExtendedColumnConfig({ name: 'name', gridTrackSize: '200px' })).toBe(true);
+      const col: ExtendedColumnConfig = { name: 'name', gridTrackSize: '200px' };
+
+      expect(isExtendedColumnConfig(col)).toBe(true);
     });
 
     it('returns false when gridTrackSize is absent', () => {
@@ -80,7 +90,9 @@ describe('GridColumnWidthService', () => {
     });
 
     it('returns false when gridTrackSize is not a string (e.g. number from malformed storage)', () => {
-      expect(isExtendedColumnConfig({ name: 'name', gridTrackSize: 200 as any })).toBe(false);
+      const col = { name: 'name', gridTrackSize: 200 } as unknown as ColumnConfig;
+
+      expect(isExtendedColumnConfig(col)).toBe(false);
     });
   });
 
@@ -88,6 +100,7 @@ describe('GridColumnWidthService', () => {
     it('restores gridTrackSize from an ExtendedColumnConfig onto the matching live column', () => {
       const destroy$ = new Subject<void>();
       const grid = makeGrid();
+
       service.applyColumnWidthPersistence(grid, destroy$.asObservable());
 
       const storedColumns: ExtendedColumnConfig[] = [
@@ -110,6 +123,7 @@ describe('GridColumnWidthService', () => {
     it('leaves columns unchanged when the stored config has no gridTrackSize', () => {
       const destroy$ = new Subject<void>();
       const grid = makeGrid();
+
       service.applyColumnWidthPersistence(grid, destroy$.asObservable());
 
       const storedColumns: ColumnConfig[] = [
@@ -138,7 +152,8 @@ describe('GridColumnWidthService', () => {
       service.applyColumnWidthPersistence(makeGrid(), d2$.asObservable());
 
       expect(dataGridService.applyConfigToColumns).toBe(patchedFn);
-      d1$.next(); d2$.next();
+      d1$.next();
+      d2$.next();
     });
   });
 
@@ -148,20 +163,21 @@ describe('GridColumnWidthService', () => {
 
   describe('saving widths after resize', () => {
     beforeEach(() => {
-      jest.useFakeTimers();
-      jest.spyOn(global, 'requestAnimationFrame').mockImplementation((cb) => { cb(0); return 0; });
-    });
+      // Run the deferred frame synchronously so the save pipeline completes inline.
+      spyOn(window, 'requestAnimationFrame').and.callFake((cb: FrameRequestCallback) => {
+        cb(0);
 
-    afterEach(() => {
-      jest.useRealTimers();
-      jest.restoreAllMocks();
+        return 0;
+      });
     });
 
     function simulateResize(grid: DataGridComponent, finalColumns: Column[]) {
-      (grid.resizeHandleMouseDown$ as Subject<any>).next({ event: {} as MouseEvent, targetColumnName: finalColumns[0].name });
+      (grid.resizeHandleMouseDown$ as Subject<any>).next({
+        event: {} as MouseEvent,
+        targetColumnName: finalColumns[0].name,
+      });
       grid.columns = finalColumns;
-      (grid.resizeHandleContainerMouseUp$ as Subject<MouseEvent>).next({} as MouseEvent);
-      jest.runAllTimers();
+      (grid.windowMouseUp$ as Subject<MouseEvent>).next({} as MouseEvent);
     }
 
     it('loads the stored config, merges current widths, and saves via configurationStrategy', () => {
@@ -170,7 +186,8 @@ describe('GridColumnWidthService', () => {
         { name: 'name', visible: true },
         { name: 'type', visible: true },
       ]);
-      (grid.configurationStrategy.getConfig$ as jest.Mock).mockReturnValue(of(storedConfig));
+
+      (grid.configurationStrategy.getConfig$ as jasmine.Spy).and.returnValue(of(storedConfig));
       const destroy$ = new Subject<void>();
 
       service.applyColumnWidthPersistence(grid, destroy$.asObservable());
@@ -178,10 +195,10 @@ describe('GridColumnWidthService', () => {
       simulateResize(grid, [makeColumn('name', '380px'), makeColumn('type', '150px')]);
 
       expect(grid.configurationStrategy.saveConfig$).toHaveBeenCalledWith(
-        expect.objectContaining({
-          columns: expect.arrayContaining([
-            expect.objectContaining({ name: 'name', gridTrackSize: '380px' }),
-            expect.objectContaining({ name: 'type', gridTrackSize: '150px' }),
+        jasmine.objectContaining({
+          columns: jasmine.arrayContaining([
+            jasmine.objectContaining({ name: 'name', gridTrackSize: '380px' }),
+            jasmine.objectContaining({ name: 'type', gridTrackSize: '150px' }),
           ]),
         })
       );
@@ -194,13 +211,16 @@ describe('GridColumnWidthService', () => {
         { name: 'name', visible: false, sortOrder: 'asc' },
         { name: 'type', visible: true },
       ]);
-      (grid.configurationStrategy.getConfig$ as jest.Mock).mockReturnValue(of(storedConfig));
+
+      (grid.configurationStrategy.getConfig$ as jasmine.Spy).and.returnValue(of(storedConfig));
       const destroy$ = new Subject<void>();
 
       service.applyColumnWidthPersistence(grid, destroy$.asObservable());
       simulateResize(grid, [makeColumn('name', '300px'), makeColumn('type', '150px')]);
 
-      const savedConfig = (grid.configurationStrategy.saveConfig$ as jest.Mock).mock.calls[0][0] as GridConfig;
+      const savedConfig = (grid.configurationStrategy.saveConfig$ as jasmine.Spy).calls.argsFor(
+        0
+      )[0] as GridConfig;
       const nameCol = savedConfig.columns.find((c) => c.name === 'name') as ExtendedColumnConfig;
 
       expect(nameCol.visible).toBe(false);
@@ -215,29 +235,29 @@ describe('GridColumnWidthService', () => {
         makeColumn('checkbox', '32px', /* positionFixed */ true),
       ]);
       const storedConfig = makeStoredConfig([{ name: 'name', visible: true }]);
-      (grid.configurationStrategy.getConfig$ as jest.Mock).mockReturnValue(of(storedConfig));
+
+      (grid.configurationStrategy.getConfig$ as jasmine.Spy).and.returnValue(of(storedConfig));
       const destroy$ = new Subject<void>();
 
       service.applyColumnWidthPersistence(grid, destroy$.asObservable());
-      simulateResize(grid, [
-        makeColumn('name', '400px'),
-        makeColumn('checkbox', '32px', true),
-      ]);
+      simulateResize(grid, [makeColumn('name', '400px'), makeColumn('checkbox', '32px', true)]);
 
-      const savedConfig = (grid.configurationStrategy.saveConfig$ as jest.Mock).mock.calls[0][0] as GridConfig;
+      const savedConfig = (grid.configurationStrategy.saveConfig$ as jasmine.Spy).calls.argsFor(
+        0
+      )[0] as GridConfig;
       const checkboxCol = savedConfig.columns.find((c) => c.name === 'checkbox');
+
       expect(checkboxCol).toBeUndefined(); // not in storedConfig.columns → not in merged output either
       destroy$.next();
     });
 
-    it('does NOT save when resizeHandleContainerMouseUp$ fires without a prior resizeHandleMouseDown$', () => {
+    it('does NOT save when windowMouseUp$ fires without a prior resizeHandleMouseDown$', () => {
       const grid = makeGrid();
       const destroy$ = new Subject<void>();
 
       service.applyColumnWidthPersistence(grid, destroy$.asObservable());
 
-      (grid.resizeHandleContainerMouseUp$ as Subject<MouseEvent>).next({} as MouseEvent);
-      jest.runAllTimers();
+      (grid.windowMouseUp$ as Subject<MouseEvent>).next({} as MouseEvent);
 
       expect(grid.configurationStrategy.saveConfig$).not.toHaveBeenCalled();
       destroy$.next();
@@ -245,6 +265,7 @@ describe('GridColumnWidthService', () => {
 
     it('is a no-op when no configurationStrategy is provided', () => {
       const grid = makeGrid();
+
       (grid as any).configurationStrategy = undefined;
 
       // Should not throw.
@@ -264,25 +285,27 @@ describe('GridColumnWidthService', () => {
 
       expect(() =>
         service.applyColumnWidthPersistence(makeGrid(), new Subject<void>().asObservable())
-      ).toThrow('DataGridService.applyConfigToColumns not found');
+      ).toThrowError(/DataGridService\.applyConfigToColumns not found/);
     });
 
     it('throws when DataGridComponent.resizeHandleMouseDown$ is not found', () => {
       const grid = makeGrid();
+
       delete (grid as any).resizeHandleMouseDown$;
 
       expect(() =>
         service.applyColumnWidthPersistence(grid, new Subject<void>().asObservable())
-      ).toThrow('DataGridComponent.resizeHandleMouseDown$ not found');
+      ).toThrowError(/DataGridComponent\.resizeHandleMouseDown\$ not found/);
     });
 
-    it('throws when DataGridComponent.resizeHandleContainerMouseUp$ is not found', () => {
+    it('throws when DataGridComponent.windowMouseUp$ is not found', () => {
       const grid = makeGrid();
-      delete (grid as any).resizeHandleContainerMouseUp$;
+
+      delete (grid as any).windowMouseUp$;
 
       expect(() =>
         service.applyColumnWidthPersistence(grid, new Subject<void>().asObservable())
-      ).toThrow('DataGridComponent.resizeHandleContainerMouseUp$ not found');
+      ).toThrowError(/DataGridComponent\.windowMouseUp\$ not found/);
     });
   });
 
@@ -292,13 +315,12 @@ describe('GridColumnWidthService', () => {
 
   describe('cleanup via until$', () => {
     beforeEach(() => {
-      jest.useFakeTimers();
-      jest.spyOn(global, 'requestAnimationFrame').mockImplementation((cb) => { cb(0); return 0; });
-    });
+      // Run the deferred frame synchronously so the save pipeline completes inline.
+      spyOn(window, 'requestAnimationFrame').and.callFake((cb: FrameRequestCallback) => {
+        cb(0);
 
-    afterEach(() => {
-      jest.useRealTimers();
-      jest.restoreAllMocks();
+        return 0;
+      });
     });
 
     it('stops listening to resize events after until$ emits', () => {
@@ -308,9 +330,11 @@ describe('GridColumnWidthService', () => {
       service.applyColumnWidthPersistence(grid, destroy$.asObservable());
       destroy$.next();
 
-      (grid.resizeHandleMouseDown$ as Subject<any>).next({ event: {} as MouseEvent, targetColumnName: 'name' });
-      (grid.resizeHandleContainerMouseUp$ as Subject<MouseEvent>).next({} as MouseEvent);
-      jest.runAllTimers();
+      (grid.resizeHandleMouseDown$ as Subject<any>).next({
+        event: {} as MouseEvent,
+        targetColumnName: 'name',
+      });
+      (grid.windowMouseUp$ as Subject<MouseEvent>).next({} as MouseEvent);
 
       expect(grid.configurationStrategy.saveConfig$).not.toHaveBeenCalled();
     });

--- a/packages/shared/src/services/grid-column-width.service.ts
+++ b/packages/shared/src/services/grid-column-width.service.ts
@@ -1,0 +1,233 @@
+import { Injectable } from '@angular/core';
+import { DataGridComponent, DataGridService } from '@c8y/ngx-components';
+import { ColumnConfig } from '@c8y/ngx-components';
+import { has, set } from 'lodash';
+import { Observable } from 'rxjs';
+import { mergeMap, switchMap, take, takeUntil } from 'rxjs/operators';
+
+/**
+ * Extends the built-in `ColumnConfig` with an optional `gridTrackSize` field.
+ *
+ * Because `DataGridService.saveConfig$` serialises the entire config object as-is,
+ * any extra fields on a `ColumnConfig` entry are persisted automatically.
+ * This type makes that extension explicit and type-safe.
+ */
+export interface ExtendedColumnConfig extends ColumnConfig {
+  gridTrackSize?: string;
+}
+
+/**
+ * Type guard that narrows a `ColumnConfig` to `ExtendedColumnConfig`.
+ * Returns `true` when the entry carries a non-empty `gridTrackSize` string,
+ * i.e. when column-width data was previously persisted for this column.
+ */
+export function isExtendedColumnConfig(col: ColumnConfig): col is ExtendedColumnConfig {
+  return 'gridTrackSize' in col && typeof (col as ExtendedColumnConfig).gridTrackSize === 'string';
+}
+
+/**
+ * Extends the built-in data grid column configuration (visibility + order) with
+ * column **width** persistence.
+ *
+ * ### How it works
+ *
+ * **Saving** – When the user finishes resizing a column the service
+ * (1) loads the latest `GridConfig` from the grid's own `configurationStrategy`,
+ * (2) merges the current `gridTrackSize` values from the live columns into the
+ * `ColumnConfig` entries as `ExtendedColumnConfig`, and
+ * (3) calls `configurationStrategy.saveConfig$` with the enriched config.
+ * No separate storage key is needed; width data lives alongside the existing
+ * order/visibility data under the same strategy key.
+ *
+ * **Restoring** – `DataGridService.applyConfigToColumns` is monkey-patched once
+ * (globally, idempotent) to also copy `gridTrackSize` from each saved
+ * `ExtendedColumnConfig` back onto the live `Column`.  Every grid that uses the
+ * same `DataGridService` instance benefits automatically.
+ *
+ * **Resize detection** – mirrors the internal `resizeHandleDrag$` pattern:
+ * `resizeHandleMouseDown$` → `mergeMap` → `resizeHandleContainerMouseUp$.pipe(take(1))`
+ * → one `requestAnimationFrame` defer (so the grid's own rAF callback that
+ * writes the final `gridTrackSize` has run before we read the values).
+ *
+ * ### Usage
+ *
+ * Call once from a `@ViewChild` setter after the grid instance is available.
+ * The grid must have a `DATA_GRID_CONFIGURATION_STRATEGY` provided; without
+ * one there is nothing to save to and the service is a no-op.
+ *
+ * ```typescript
+ * private destroy$ = new Subject<void>();
+ *
+ * @ViewChild(DataGridComponent, { static: false })
+ * set grid(grid: DataGridComponent) {
+ *   if (grid) {
+ *     this.gridColumnWidthService.applyColumnWidthPersistence(
+ *       grid,
+ *       this.destroy$.asObservable()
+ *     );
+ *   }
+ * }
+ *
+ * ngOnDestroy(): void {
+ *   this.destroy$.next();
+ *   this.destroy$.complete();
+ * }
+ * ```
+ *
+ * WARNING: This service accesses public-but-undocumented properties of
+ * `DataGridComponent` (`resizeHandleMouseDown$`, `resizeHandleContainerMouseUp$`,
+ * `configurationStrategy`) and monkey-patches `DataGridService.applyConfigToColumns`.
+ * It may break in future versions of `@c8y/ngx-components`.
+ */
+@Injectable({ providedIn: 'root' })
+export class GridColumnWidthService {
+  /** Marker placed on `DataGridService` to prevent double-patching. */
+  private readonly PATCH_MARKER = '__c8yGridColumnWidthPatched';
+
+  constructor(private dataGridService: DataGridService) {}
+
+  /**
+   * Enables column-width persistence for the given `DataGridComponent`.
+   *
+   * @param grid    The `DataGridComponent` instance obtained via `@ViewChild`.
+   * @param until$  Observable whose first emission unsubscribes all internal
+   *                listeners.  Pass your component's `destroy$` subject.
+   */
+  applyColumnWidthPersistence(grid: DataGridComponent, until$: Observable<void>): void {
+    this.patchApplyConfigToColumns();
+    this.setupResizeSave(grid, until$);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Monkey-patches `DataGridService.applyConfigToColumns` so that a saved
+   * `gridTrackSize` value on an `ExtendedColumnConfig` is copied back onto the
+   * live `Column` after the standard visibility/order/filter restoration.
+   *
+   * The patch is idempotent – subsequent calls are no-ops.
+   * Because `DataGridService` is `providedIn: 'root'`, this patch applies to
+   * every grid in the application, but it is purely additive: columns without
+   * a saved `gridTrackSize` are unaffected.
+   */
+  private patchApplyConfigToColumns(): void {
+    if (has(this.dataGridService, this.PATCH_MARKER)) {
+      return;
+    }
+
+    if (!has(this.dataGridService, 'applyConfigToColumns')) {
+      throw new Error(
+        'GridColumnWidthService: patching failed. ' +
+          'DataGridService.applyConfigToColumns not found.'
+      );
+    }
+
+    set(this.dataGridService, this.PATCH_MARKER, true);
+
+    const original = this.dataGridService.applyConfigToColumns.bind(this.dataGridService);
+
+    this.dataGridService.applyConfigToColumns = (config, columns, storageKey?) => {
+      const result = original(config, columns, storageKey);
+
+      config?.columns?.forEach((savedCol) => {
+        if (isExtendedColumnConfig(savedCol)) {
+          const col = result.find((c) => c.name === savedCol.name);
+
+          if (col) {
+            col.gridTrackSize = savedCol.gridTrackSize;
+          }
+        }
+      });
+
+      return result;
+    };
+  }
+
+  /**
+   * Mirrors the internal `resizeHandleDrag$` pipeline from `DataGridComponent`:
+   * for each `resizeHandleMouseDown$` emission, waits for the next
+   * `resizeHandleContainerMouseUp$` via `mergeMap` + `take(1)`, then defers one
+   * `requestAnimationFrame` tick before reading column widths.
+   *
+   * On completion, loads the current stored config from the grid's own
+   * `configurationStrategy`, merges the live `gridTrackSize` values into the
+   * `ColumnConfig` entries, and saves the enriched config back via the same
+   * strategy — no separate storage key required.
+   */
+  private setupResizeSave(grid: DataGridComponent, until$: Observable<void>): void {
+    if (!grid.configurationStrategy) {
+      return;
+    }
+
+    if (!has(grid, 'resizeHandleMouseDown$')) {
+      throw new Error(
+        'GridColumnWidthService: patching failed. ' +
+          'DataGridComponent.resizeHandleMouseDown$ not found.'
+      );
+    }
+
+    if (!has(grid, 'resizeHandleContainerMouseUp$')) {
+      throw new Error(
+        'GridColumnWidthService: patching failed. ' +
+          'DataGridComponent.resizeHandleContainerMouseUp$ not found.'
+      );
+    }
+
+    grid.resizeHandleMouseDown$
+      .pipe(
+        takeUntil(until$),
+        mergeMap(() =>
+          grid.resizeHandleContainerMouseUp$.pipe(
+            take(1),
+            // Defer one animation frame so the grid's own requestAnimationFrame
+            // callback — which writes the final gridTrackSize — executes first.
+            mergeMap(
+              () =>
+                new Observable<void>((observer) => {
+                  requestAnimationFrame(() => {
+                    observer.next();
+                    observer.complete();
+                  });
+                })
+            )
+          )
+        ),
+        // Load the current stored config, merge widths, save back.
+        // switchMap cancels any in-flight load if another resize completes first.
+        switchMap(() =>
+          grid.configurationStrategy.getConfig$().pipe(
+            take(1),
+            switchMap((storedConfig) => {
+              const widths = this.buildWidthMap(grid);
+              const columns: ExtendedColumnConfig[] = (storedConfig?.columns ?? []).map((col) => ({
+                ...col,
+                ...(widths[col.name] ? { gridTrackSize: widths[col.name] } : {}),
+              }));
+
+              return grid.configurationStrategy.saveConfig$({
+                ...storedConfig,
+                columns,
+              });
+            })
+          )
+        )
+      )
+      .subscribe();
+  }
+
+  /**
+   * Builds a `{ columnName → gridTrackSize }` map from the grid's current live
+   * columns, excluding special fixed-position columns (checkbox, actions, etc.).
+   */
+  private buildWidthMap(grid: DataGridComponent): Record<string, string> {
+    return grid.columns
+      .filter((col) => !col.positionFixed && col.gridTrackSize)
+      .reduce<Record<string, string>>((acc, col) => {
+        acc[col.name] = col.gridTrackSize;
+
+        return acc;
+      }, {});
+  }
+}

--- a/packages/shared/src/services/grid-column-width.service.ts
+++ b/packages/shared/src/services/grid-column-width.service.ts
@@ -45,7 +45,7 @@ export function isExtendedColumnConfig(col: ColumnConfig): col is ExtendedColumn
  * same `DataGridService` instance benefits automatically.
  *
  * **Resize detection** – mirrors the internal `resizeHandleDrag$` pattern:
- * `resizeHandleMouseDown$` → `mergeMap` → `resizeHandleContainerMouseUp$.pipe(take(1))`
+ * `resizeHandleMouseDown$` → `mergeMap` → `windowMouseUp$.pipe(take(1))`
  * → one `requestAnimationFrame` defer (so the grid's own rAF callback that
  * writes the final `gridTrackSize` has run before we read the values).
  *
@@ -75,7 +75,7 @@ export function isExtendedColumnConfig(col: ColumnConfig): col is ExtendedColumn
  * ```
  *
  * WARNING: This service accesses public-but-undocumented properties of
- * `DataGridComponent` (`resizeHandleMouseDown$`, `resizeHandleContainerMouseUp$`,
+ * `DataGridComponent` (`resizeHandleMouseDown$`, `windowMouseUp$`,
  * `configurationStrategy`) and monkey-patches `DataGridService.applyConfigToColumns`.
  * It may break in future versions of `@c8y/ngx-components`.
  */
@@ -148,7 +148,7 @@ export class GridColumnWidthService {
   /**
    * Mirrors the internal `resizeHandleDrag$` pipeline from `DataGridComponent`:
    * for each `resizeHandleMouseDown$` emission, waits for the next
-   * `resizeHandleContainerMouseUp$` via `mergeMap` + `take(1)`, then defers one
+   * `windowMouseUp$` via `mergeMap` + `take(1)`, then defers one
    * `requestAnimationFrame` tick before reading column widths.
    *
    * On completion, loads the current stored config from the grid's own
@@ -168,10 +168,9 @@ export class GridColumnWidthService {
       );
     }
 
-    if (!has(grid, 'resizeHandleContainerMouseUp$')) {
+    if (!has(grid, 'windowMouseUp$')) {
       throw new Error(
-        'GridColumnWidthService: patching failed. ' +
-          'DataGridComponent.resizeHandleContainerMouseUp$ not found.'
+        'GridColumnWidthService: patching failed. DataGridComponent.windowMouseUp$ not found.'
       );
     }
 
@@ -179,7 +178,7 @@ export class GridColumnWidthService {
       .pipe(
         takeUntil(until$),
         mergeMap(() =>
-          grid.resizeHandleContainerMouseUp$.pipe(
+          grid.windowMouseUp$.pipe(
             take(1),
             // Defer one animation frame so the grid's own requestAnimationFrame
             // callback — which writes the final gridTrackSize — executes first.
@@ -201,10 +200,14 @@ export class GridColumnWidthService {
             take(1),
             switchMap((storedConfig) => {
               const widths = this.buildWidthMap(grid);
-              const columns: ExtendedColumnConfig[] = (storedConfig?.columns ?? []).map((col) => ({
-                ...col,
-                ...(widths[col.name] ? { gridTrackSize: widths[col.name] } : {}),
-              }));
+              const columns: ExtendedColumnConfig[] = (storedConfig?.columns ?? []).map((col) => {
+                const gridTrackSize = col.name ? widths[col.name] : undefined;
+
+                return {
+                  ...col,
+                  ...(gridTrackSize ? { gridTrackSize } : {}),
+                };
+              });
 
               return grid.configurationStrategy.saveConfig$({
                 ...storedConfig,
@@ -225,7 +228,9 @@ export class GridColumnWidthService {
     return grid.columns
       .filter((col) => !col.positionFixed && col.gridTrackSize)
       .reduce<Record<string, string>>((acc, col) => {
-        acc[col.name] = col.gridTrackSize;
+        if (col.name && col.gridTrackSize) {
+          acc[col.name] = col.gridTrackSize;
+        }
 
         return acc;
       }, {});


### PR DESCRIPTION
Add GridColumnWidthService, which extends the built-in data grid column
configuration (visibility and order) with column width persistence.

Widths are stored as a gridTrackSize field on each ColumnConfig entry via
the grid's existing DATA_GRID_CONFIGURATION_STRATEGY, so no separate
storage key is needed. Saving is triggered on resize-handle mouse-up;
restoring works by patching DataGridService.applyConfigToColumns once so
every grid sharing the service instance picks up saved widths.