### PR TITLE
feat(index-db-cache): live cache stats via signals and read-activity LED

### DIFF
--- a/packages/index-db-cache/package.json
+++ b/packages/index-db-cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cumulocity-index-db-cache-plugin",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "author": "",
   "homepage": "___TODO___",

--- a/packages/index-db-cache/src/app/index-db-cache-action/index-db-cache-action.component.html
+++ b/packages/index-db-cache/src/app/index-db-cache-action/index-db-cache-action.component.html
@@ -5,18 +5,19 @@
     [priority]="priority"
   >
     <button
-      class="btn btn-link"
+      class="btn btn-link idb-toggle"
       [attr.aria-label]="'IndexedDB cache' | translate"
       tooltip="{{ 'IndexedDB cache' | translate }}"
       placement="left"
       container="body"
       aria-controls="collapseCache"
-      [attr.aria-expanded]="!isCollapsed"
+      [attr.aria-expanded]="!isCollapsed()"
       type="button"
       data-cy="index-db-cache--toggle"
       (click)="toggle()"
     >
       <i c8yIcon="smartphone-ram"></i>
+      <span class="idb-led" [class.idb-led--on]="readingFromDb()" aria-hidden="true"></span>
     </button>
   </c8y-action-bar-item>
 }
@@ -24,9 +25,8 @@
 <div
   class="c8y-help-drawer"
   id="collapseCache"
-  [collapse]="isCollapsed"
+  [collapse]="isCollapsed()"
   [isAnimated]="true"
-  (collapsed)="onCollapsed()"
 >
   <div class="c8y-help-drawer-block">
 
@@ -37,6 +37,12 @@
         <h4 class="text-bold text-primary m-0" translate>IndexedDB Cache</h4>
         <small class="text-muted" translate>Manage the browser-side IndexedDB cache.</small>
       </div>
+      <span
+        class="idb-led idb-led--lg"
+        [class.idb-led--on]="readingFromDb()"
+        tooltip="{{ 'Reading from IndexedDB' | translate }}"
+        placement="left"
+      ></span>
     </div>
 
     <!-- ─── Cache Control ─────────────────────── -->
@@ -47,13 +53,13 @@
         <label class="c8y-switch m-b-0">
           <input
             type="checkbox"
-            [checked]="cachingActive"
+            [checked]="cachingActive()"
             (change)="onActiveToggle($event)"
           />
           <span></span>
         </label>
-        <span [class]="cachingActive ? 'text-success' : 'text-muted'">
-          @if (cachingActive) {
+        <span [class]="cachingActive() ? 'text-success' : 'text-muted'">
+          @if (cachingActive()) {
             <i c8yIcon="check-circle"></i>
             <strong translate> Caching active</strong>
           } @else {
@@ -68,78 +74,64 @@
 
     <!-- ─── Statistics ───────────────────────── -->
     <fieldset class="m-b-16">
-      <legend>
-        <div class="d-flex a-i-center j-c-between">
-          <span translate>Statistics</span>
-          <button
-            class="btn btn-xs btn-clean"
-            tooltip="{{ 'Refresh statistics' | translate }}"
-            (click)="refreshStats()"
-            [disabled]="loadingStats"
-            type="button"
-          >
-            <i [c8yIcon]="loadingStats ? 'circle-o-notch' : 'refresh'" [class.idb-spin]="loadingStats"></i>
-          </button>
-        </div>
-      </legend>
+      <legend translate>Statistics</legend>
 
-      @if (statRows[0].stats !== undefined) {
+      @if (statRows(); as rows) {
         <table class="table table-condensed m-b-8">
           <thead>
             <tr>
               <th translate>Cache</th>
               <th class="text-right" translate>Entries</th>
-              <th class="text-right" translate>Est. Size</th>
-              <th></th>
             </tr>
           </thead>
           <tbody>
-            @for (row of statRows; track row.name) {
+            @for (row of rows; track row.name) {
               <tr>
                 <td>
                   <span class="idb-badge" [class]="'idb-badge--' + row.name">{{ row.shortLabel }}</span>
                 </td>
-                <td class="text-right">
-                  @if (row.stats) { {{ row.stats.elementCount | number }} } @else { — }
-                </td>
-                <td class="text-right text-muted">
-                  @if (row.stats) { {{ row.stats.storageSizeMB | number:'1.1-1' }}&nbsp;MB } @else { — }
-                </td>
-                <td class="text-right">
-                  <button
-                    class="btn btn-xs btn-danger"
-                    tooltip="{{ 'Clear cache' | translate }}"
-                    (click)="clearCache(row.name)"
-                    [disabled]="clearingCache === row.name"
-                    type="button"
-                  >
-                    <i [c8yIcon]="clearingCache === row.name ? 'circle-o-notch' : 'trash'" [class.idb-spin]="clearingCache === row.name"></i>
-                  </button>
-                </td>
+                <td class="text-right">{{ row.elementCount | number }}</td>
               </tr>
             }
           </tbody>
         </table>
 
+        <div class="d-flex a-i-center j-c-between m-b-16">
+          <small class="text-muted">
+            <span translate>Estimated storage used</span>:
+            <strong>{{ stats()?.storageSizeMB | number:'1.1-1' }}&nbsp;MB</strong>
+          </small>
+          <button
+            class="btn btn-xs btn-danger"
+            (click)="clearAllCaches()"
+            [disabled]="clearing()"
+            type="button"
+            data-cy="index-db-cache--clear-all"
+          >
+            <i [c8yIcon]="clearing() ? 'circle-o-notch' : 'trash'" [class.idb-spin]="clearing()"></i>
+            <span translate> Clear all caches</span>
+          </button>
+        </div>
+
         <!-- Bandwidth saved progress bar -->
         <div class="d-flex j-c-between m-b-4">
           <small class="text-muted" translate>Bandwidth saved (current log)</small>
           <small class="text-success">
-            <strong>{{ logService.savedPercent | number:'1.0-0' }}%</strong>
-            &nbsp;~{{ logService.totalSavedKB | number:'1.0-0' }}&nbsp;KB
+            <strong>{{ savedPercent() | number:'1.0-0' }}%</strong>
+            &nbsp;~{{ totalSavedKB() | number:'1.0-0' }}&nbsp;KB
           </small>
         </div>
         <div class="progress idb-progress">
           <div
             class="progress-bar progress-bar-success"
             role="progressbar"
-            [style.width]="logService.savedPercent + '%'"
+            [style.width.%]="savedPercent()"
           ></div>
         </div>
       } @else {
         <p class="text-muted small m-0">
-          <i c8yIcon="info-circle"></i>
-          <span translate> Click refresh to load statistics.</span>
+          <i c8yIcon="circle-o-notch" class="idb-spin"></i>
+          <span translate> Loading statistics…</span>
         </p>
       }
     </fieldset>
@@ -161,11 +153,11 @@
       </legend>
 
       <div class="idb-log">
-        @for (entry of logs$ | async; track entry.id) {
+        @for (entry of logs(); track entry.id) {
           <div class="idb-log__entry" [class]="'idb-log__entry--' + entry.eventType">
             <span class="idb-log__time">{{ entry.ts | date:'HH:mm:ss' }}</span>
             <span class="idb-badge" [class]="'idb-badge--' + entry.cache">{{ entry.cache }}</span>
-            <i [c8yIcon]="logIcon(entry.eventType)" [class]="logIconClass(entry.eventType)"></i>
+            <i [c8yIcon]="logIcons[entry.eventType]" [class]="logIconClasses[entry.eventType]"></i>
             <span class="idb-log__meta flex-grow">
               @if (entry.keys.length) { {{ entry.keys.join(', ') }} · }
               <span class="text-muted">
@@ -190,7 +182,7 @@
       aria-controls="collapseCache"
       type="button"
       class="btn btn-default"
-      [attr.aria-expanded]="!isCollapsed"
+      [attr.aria-expanded]="!isCollapsed()"
       data-cy="index-db-cache--close"
       (click)="toggle()"
       translate

--- a/packages/index-db-cache/src/app/index-db-cache-action/index-db-cache-action.component.less
+++ b/packages/index-db-cache/src/app/index-db-cache-action/index-db-cache-action.component.less
@@ -26,6 +26,39 @@
   animation: idb-spin 0.75s linear infinite;
 }
 
+// ─── Read-activity indicator ──────────────────────────────────────────────────
+// Floppy-drive style LED: lights green while data is read from IndexedDB.
+
+.idb-toggle {
+  position: relative;
+}
+
+.idb-led {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--c8y-palette-gray-60);
+  transition: background-color 100ms ease-out, box-shadow 100ms ease-out;
+
+  .idb-toggle & {
+    position: absolute;
+    right: 6px;
+    bottom: 6px;
+  }
+
+  &--lg {
+    width: 9px;
+    height: 9px;
+    flex-shrink: 0;
+  }
+
+  &--on {
+    background: var(--c8y-palette-status-success);
+    box-shadow: 0 0 5px 1px var(--c8y-palette-status-success);
+  }
+}
+
 // ─── Progress bar ─────────────────────────────────────────────────────────────
 
 .idb-progress {
@@ -46,18 +79,18 @@
   line-height: 1.6;
 
   &--new-series {
-    background: #e8f0fe;
-    color: #1a73e8;
+    background: var(--c8y-palette-status-info-light);
+    color: var(--c8y-palette-status-info-dark);
   }
 
   &--old-series {
-    background: #e6f4f1;
-    color: #0f9d58;
+    background: var(--c8y-palette-status-success-light);
+    color: var(--c8y-palette-status-success-dark);
   }
 
   &--measurement {
-    background: #fce8b2;
-    color: #f9ab00;
+    background: var(--c8y-palette-status-warning-light);
+    color: var(--c8y-palette-status-warning-dark);
   }
 }
 
@@ -66,9 +99,9 @@
 .idb-log {
   max-height: 280px;
   overflow-y: auto;
-  border: 1px solid #e0e0e0;
+  border: 1px solid var(--c8y-global-separator);
   border-radius: 4px;
-  font-family: monospace;
+  font-family: var(--c8y-font-family-mono-spaced, monospace);
   font-size: 11px;
 
   &__entry {
@@ -77,28 +110,28 @@
     gap: 6px;
     padding: 3px 8px;
     border-left: 3px solid transparent;
-    border-bottom: 1px solid #f5f5f5;
+    border-bottom: 1px solid var(--c8y-global-separator);
 
     &:last-child {
       border-bottom: none;
     }
 
     &--cache-hit {
-      border-left-color: #5cb85c;
+      border-left-color: var(--c8y-palette-status-success);
     }
 
     &--partial-cache {
-      border-left-color: #f0ad4e;
+      border-left-color: var(--c8y-palette-status-warning);
     }
 
     &--passthrough {
-      border-left-color: #d9d9d9;
+      border-left-color: var(--c8y-palette-gray-60);
     }
   }
 
   &__time {
     flex-shrink: 0;
-    color: #9e9e9e;
+    color: var(--c8y-text-muted);
   }
 
   &__meta {

--- a/packages/index-db-cache/src/app/index-db-cache-action/index-db-cache-action.component.ts
+++ b/packages/index-db-cache/src/app/index-db-cache-action/index-db-cache-action.component.ts
@@ -1,30 +1,47 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  inject,
+  signal,
+} from '@angular/core';
 import { CoreModule } from '@c8y/ngx-components';
 import { CollapseModule } from 'ngx-bootstrap/collapse';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
-import { Observable, Subject, takeUntil } from 'rxjs';
-import {
-  CacheLogEntry,
-  CacheLogService,
-  CacheName,
-  LogEventType,
-} from './services/cache-log.service';
+import { CacheEventsService } from './services/cache-events.service';
+import { CacheName, CacheLogService, LogEventType } from './services/cache-log.service';
 import { CacheStateService } from './services/cache-state.service';
-import { MeasurementCacheService } from './services/measurement-cache.service';
-import { NewSeriesCacheService } from './services/new-series-cache.service';
-import { OldSeriesCacheService } from './services/old-series-cache.service';
-
-interface CacheStats {
-  elementCount: number;
-  storageSizeMB: number;
-}
+import { CacheStatsService } from './services/cache-stats.service';
 
 interface StatRow {
   name: CacheName;
-  label: string;
   shortLabel: string;
-  stats: CacheStats | undefined;
+  elementCount: number;
 }
+
+const CACHE_LABELS: { name: CacheName; shortLabel: string }[] = [
+  { name: 'new-series', shortLabel: 'New Series' },
+  { name: 'old-series', shortLabel: 'Old Series' },
+  { name: 'measurement', shortLabel: 'Measurements' },
+];
+
+const LOG_ICONS: Record<LogEventType, string> = {
+  'cache-hit': 'check-circle',
+  'partial-cache': 'bolt',
+  'gap-skipped': 'forward',
+  passthrough: 'cloud-download',
+};
+
+const LOG_ICON_CLASSES: Record<LogEventType, string> = {
+  'cache-hit': 'text-success',
+  'partial-cache': 'text-warning',
+  'gap-skipped': 'text-muted',
+  passthrough: 'text-info',
+};
+
+/** How long the read-activity indicator stays lit after the last read. */
+const LED_LINGER_MS = 400;
 
 @Component({
   selector: 'index-db-cache-action',
@@ -32,166 +49,80 @@ interface StatRow {
   styleUrl: './index-db-cache-action.component.less',
   standalone: true,
   imports: [CoreModule, CollapseModule, TooltipModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class IndexDbCacheActionComponent implements OnInit, OnDestroy {
-  isVisible = true;
-  isCollapsed = true;
-  priority = 100;
+export class IndexDbCacheActionComponent {
+  readonly isVisible = true;
+  readonly priority = 100;
+  readonly isCollapsed = signal(true);
 
-  /** Current value of the caching-active toggle. */
-  cachingActive = true;
+  readonly logIcons = LOG_ICONS;
+  readonly logIconClasses = LOG_ICON_CLASSES;
 
-  /** Per-cache statistics — `undefined` while not yet loaded. */
-  statsMap: Partial<Record<CacheName, CacheStats>> = {};
-  loadingStats = false;
+  private readonly cacheState = inject(CacheStateService);
+  private readonly cacheStats = inject(CacheStatsService);
+  private readonly logService = inject(CacheLogService);
+  private readonly events = inject(CacheEventsService);
 
-  /** Which cache's `clearAll()` is currently in flight. */
-  clearingCache: CacheName | null = null;
+  readonly cachingActive = this.cacheState.active;
+  readonly stats = this.cacheStats.stats;
+  readonly clearing = this.cacheStats.clearing;
+  readonly logs = this.logService.entries;
+  readonly savedPercent = this.logService.savedPercent;
+  readonly totalSavedKB = this.logService.totalSavedKB;
 
-  /** Observable stream of live log entries (newest first). */
-  logs$!: Observable<CacheLogEntry[]>;
+  /** Lights up briefly on every IndexedDB read — a floppy-drive style indicator. */
+  readonly readingFromDb = signal(false);
 
-  private readonly destroy$ = new Subject<void>();
+  readonly statRows = computed<StatRow[] | undefined>(() => {
+    const counts = this.stats()?.counts;
 
-  constructor(
-    private readonly newSeriesCache: NewSeriesCacheService,
-    private readonly oldSeriesCache: OldSeriesCacheService,
-    private readonly measurementCache: MeasurementCacheService,
-    readonly cacheState: CacheStateService,
-    readonly logService: CacheLogService
-  ) {}
+    if (!counts) return undefined;
 
-  ngOnInit(): void {
-    this.cachingActive = this.cacheState.isActive;
-    this.logs$ = this.logService.entries$;
+    return CACHE_LABELS.map(({ name, shortLabel }) => ({
+      name,
+      shortLabel,
+      elementCount: counts[name],
+    }));
+  });
 
-    // Sync toggle state if changed externally (e.g. another tab)
-    this.cacheState.isActive$
-      .pipe(takeUntil(this.destroy$))
-      .subscribe((active) => (this.cachingActive = active));
+  private ledHandle: ReturnType<typeof setTimeout> | null = null;
+
+  constructor() {
+    effect(() => {
+      // Skip the effect's initial run — no read has happened yet.
+      if (this.events.readActivity() > 0) {
+        this.flashReadIndicator();
+      }
+    });
   }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
-  }
-
-  // ─── Action bar item ──────────────────────────────────────────────────────────
 
   toggle(): void {
-    this.isCollapsed = !this.isCollapsed;
-
-    if (!this.isCollapsed && !Object.keys(this.statsMap).length) {
-      void this.refreshStats();
-    }
+    this.isCollapsed.update((collapsed) => !collapsed);
   }
-
-  onCollapsed(): void {
-    /* noop — hook for post-collapse side effects */
-  }
-
-  // ─── Cache Control section ────────────────────────────────────────────────────
 
   onActiveToggle(event: Event): void {
     this.cacheState.setActive((event.target as HTMLInputElement).checked);
   }
 
-  // ─── Statistics section ───────────────────────────────────────────────────────
-
-  get statRows(): StatRow[] {
-    return [
-      {
-        name: 'new-series',
-        label: 'New Series (aggregationInterval)',
-        shortLabel: 'New Series',
-        stats: this.statsMap['new-series'],
-      },
-      {
-        name: 'old-series',
-        label: 'Old Series (aggregationType)',
-        shortLabel: 'Old Series',
-        stats: this.statsMap['old-series'],
-      },
-      {
-        name: 'measurement',
-        label: 'Raw Measurements',
-        shortLabel: 'Measurements',
-        stats: this.statsMap['measurement'],
-      },
-    ];
+  clearAllCaches(): void {
+    void this.cacheStats.clearAll();
   }
-
-  async refreshStats(): Promise<void> {
-    this.loadingStats = true;
-
-    try {
-      const [newSeries, oldSeries, measurement] = await Promise.all([
-        this.newSeriesCache.getStats(),
-        this.oldSeriesCache.getStats(),
-        this.measurementCache.getStats(),
-      ]);
-
-      this.statsMap = { 'new-series': newSeries, 'old-series': oldSeries, measurement };
-    } catch {
-      /* IndexedDB unavailable in this context */
-    } finally {
-      this.loadingStats = false;
-    }
-  }
-
-  async clearCache(name: CacheName): Promise<void> {
-    this.clearingCache = name;
-
-    try {
-      await this.cacheForName(name).clearAll();
-    } finally {
-      this.clearingCache = null;
-      await this.refreshStats();
-    }
-  }
-
-  private cacheForName(
-    name: CacheName
-  ): NewSeriesCacheService | OldSeriesCacheService | MeasurementCacheService {
-    switch (name) {
-      case 'new-series':
-        return this.newSeriesCache;
-      case 'old-series':
-        return this.oldSeriesCache;
-      case 'measurement':
-        return this.measurementCache;
-    }
-  }
-
-  // ─── Live log section ─────────────────────────────────────────────────────────
 
   clearLog(): void {
     this.logService.clearLog();
   }
 
-  logIcon(type: LogEventType): string {
-    switch (type) {
-      case 'cache-hit':
-        return 'check-circle';
-      case 'partial-cache':
-        return 'bolt';
-      case 'gap-skipped':
-        return 'forward';
-      default:
-        return 'cloud-download';
-    }
-  }
+  private flashReadIndicator(): void {
+    this.readingFromDb.set(true);
 
-  logIconClass(type: LogEventType): string {
-    switch (type) {
-      case 'cache-hit':
-        return 'text-success';
-      case 'partial-cache':
-        return 'text-warning';
-      case 'gap-skipped':
-        return 'text-muted';
-      default:
-        return 'text-info';
+    if (this.ledHandle !== null) {
+      clearTimeout(this.ledHandle);
     }
+
+    this.ledHandle = setTimeout(() => {
+      this.ledHandle = null;
+      this.readingFromDb.set(false);
+    }, LED_LINGER_MS);
   }
 }

--- a/packages/index-db-cache/src/app/index-db-cache-action/services/cache-events.service.ts
+++ b/packages/index-db-cache/src/app/index-db-cache-action/services/cache-events.service.ts
@@ -1,0 +1,26 @@
+import { Injectable, signal } from '@angular/core';
+
+/**
+ * Broadcasts IndexedDB cache activity as signals so the UI can stay in sync
+ * without polling or manual refreshes.
+ *
+ * The three cache services notify on every write, clear and read; consumers
+ * ({@link CacheStatsService} for entry counts, the action component for the
+ * read-activity indicator) react via `effect()`.
+ */
+@Injectable({ providedIn: 'root' })
+export class CacheEventsService {
+  /** Bumped whenever cached data was written or removed. */
+  readonly changed = signal(0);
+
+  /** Bumped whenever data was read back out of IndexedDB. */
+  readonly readActivity = signal(0);
+
+  notifyChanged(): void {
+    this.changed.update((n) => n + 1);
+  }
+
+  notifyRead(): void {
+    this.readActivity.update((n) => n + 1);
+  }
+}

--- a/packages/index-db-cache/src/app/index-db-cache-action/services/cache-log.service.ts
+++ b/packages/index-db-cache/src/app/index-db-cache-action/services/cache-log.service.ts
@@ -1,5 +1,4 @@
-import { Injectable } from '@angular/core';
-import { BehaviorSubject } from 'rxjs';
+import { Injectable, computed, signal } from '@angular/core';
 
 // ─── Public types ─────────────────────────────────────────────────────────────
 
@@ -58,40 +57,35 @@ const MAX_ENTRIES = 200;
  */
 @Injectable({ providedIn: 'root' })
 export class CacheLogService {
-  private seq = 0;
-  private _totalCachedBytes = 0;
-  private _totalFetchedBytes = 0;
-
-  private readonly _entries$ = new BehaviorSubject<CacheLogEntry[]>([]);
-
-  /** Observable stream of the current log ring-buffer (newest first). */
-  readonly entries$ = this._entries$.asObservable();
+  /** The current log ring-buffer (newest first). */
+  readonly entries = signal<CacheLogEntry[]>([]);
 
   /** Percentage of total bytes served from cache vs fetched from API (0–100). */
-  get savedPercent(): number {
-    const total = this._totalCachedBytes + this._totalFetchedBytes;
+  readonly savedPercent = computed(() => {
+    const total = this.totalCachedBytes() + this.totalFetchedBytes();
 
-    return total > 0 ? Math.round((this._totalCachedBytes / total) * 100) : 0;
-  }
+    return total > 0 ? Math.round((this.totalCachedBytes() / total) * 100) : 0;
+  });
 
   /** Total bytes served from cache across all tracked requests, in KB. */
-  get totalSavedKB(): number {
-    return Math.round(this._totalCachedBytes / 1024);
-  }
+  readonly totalSavedKB = computed(() => Math.round(this.totalCachedBytes() / 1024));
+
+  private seq = 0;
+  private readonly totalCachedBytes = signal(0);
+  private readonly totalFetchedBytes = signal(0);
 
   push(entry: Omit<CacheLogEntry, 'id' | 'ts'>): void {
-    this._totalCachedBytes += entry.cachedBytes;
-    this._totalFetchedBytes += entry.fetchedBytes;
+    this.totalCachedBytes.update((b) => b + entry.cachedBytes);
+    this.totalFetchedBytes.update((b) => b + entry.fetchedBytes);
 
     const full: CacheLogEntry = { ...entry, id: ++this.seq, ts: new Date() };
-    const prev = this._entries$.value;
 
-    this._entries$.next([full, ...prev].slice(0, MAX_ENTRIES));
+    this.entries.update((prev) => [full, ...prev].slice(0, MAX_ENTRIES));
   }
 
   clearLog(): void {
-    this._totalCachedBytes = 0;
-    this._totalFetchedBytes = 0;
-    this._entries$.next([]);
+    this.totalCachedBytes.set(0);
+    this.totalFetchedBytes.set(0);
+    this.entries.set([]);
   }
 }

--- a/packages/index-db-cache/src/app/index-db-cache-action/services/cache-state.service.ts
+++ b/packages/index-db-cache/src/app/index-db-cache-action/services/cache-state.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, signal } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 
 const LS_KEY = 'c8y-idb-cache-active';
@@ -14,6 +14,9 @@ const LS_KEY = 'c8y-idb-cache-active';
 export class CacheStateService {
   readonly isActive$ = new BehaviorSubject<boolean>(this.readStorage());
 
+  /** Signal mirror of {@link isActive$} for template/`computed()` consumers. */
+  readonly active = signal(this.isActive$.value);
+
   get isActive(): boolean {
     return this.isActive$.value;
   }
@@ -26,6 +29,7 @@ export class CacheStateService {
     }
 
     this.isActive$.next(active);
+    this.active.set(active);
   }
 
   private readStorage(): boolean {

--- a/packages/index-db-cache/src/app/index-db-cache-action/services/cache-stats.service.ts
+++ b/packages/index-db-cache/src/app/index-db-cache-action/services/cache-stats.service.ts
@@ -1,0 +1,114 @@
+import { Injectable, effect, inject, signal } from '@angular/core';
+import { CacheEventsService } from './cache-events.service';
+import { CacheName } from './cache-log.service';
+import { MeasurementCacheService } from './measurement-cache.service';
+import { NewSeriesCacheService } from './new-series-cache.service';
+import { OldSeriesCacheService } from './old-series-cache.service';
+
+export interface CacheStatsState {
+  /** Number of cached data entries per cache. */
+  counts: Record<CacheName, number>;
+  /**
+   * Origin-wide storage usage in MB as reported by the Storage API. This
+   * cannot be attributed per cache, so it is tracked once globally.
+   */
+  storageSizeMB: number;
+}
+
+/** Collapses bursts of cache writes into a single recount. */
+const REFRESH_DEBOUNCE_MS = 300;
+
+/**
+ * Keeps live entry counts for the three IndexedDB caches, recounting whenever
+ * {@link CacheEventsService} reports a write or clear — no manual refresh.
+ */
+@Injectable({ providedIn: 'root' })
+export class CacheStatsService {
+  /** `undefined` until the first count has completed. */
+  readonly stats = signal<CacheStatsState | undefined>(undefined);
+  readonly clearing = signal(false);
+
+  private readonly events = inject(CacheEventsService);
+  private readonly newSeriesCache = inject(NewSeriesCacheService);
+  private readonly oldSeriesCache = inject(OldSeriesCacheService);
+  private readonly measurementCache = inject(MeasurementCacheService);
+
+  private debounceHandle: ReturnType<typeof setTimeout> | null = null;
+  /** Guards against an earlier, slower recount overwriting a newer result. */
+  private refreshToken = 0;
+
+  constructor() {
+    effect(() => {
+      this.events.changed();
+      this.scheduleRefresh();
+    });
+  }
+
+  async clearAll(): Promise<void> {
+    this.clearing.set(true);
+
+    try {
+      await Promise.all([
+        this.newSeriesCache.clearAll(),
+        this.oldSeriesCache.clearAll(),
+        this.measurementCache.clearAll(),
+      ]);
+    } catch {
+      /* IndexedDB unavailable in this context */
+    } finally {
+      this.clearing.set(false);
+    }
+  }
+
+  private scheduleRefresh(): void {
+    if (this.debounceHandle !== null) {
+      clearTimeout(this.debounceHandle);
+    }
+
+    this.debounceHandle = setTimeout(() => {
+      this.debounceHandle = null;
+      void this.refresh();
+    }, REFRESH_DEBOUNCE_MS);
+  }
+
+  private async refresh(): Promise<void> {
+    const token = ++this.refreshToken;
+
+    try {
+      const [newSeries, oldSeries, measurement, storageSizeMB] = await Promise.all([
+        this.newSeriesCache.getStats(),
+        this.oldSeriesCache.getStats(),
+        this.measurementCache.getStats(),
+        this.estimateStorageMB(),
+      ]);
+
+      // A newer recount finished first — keep its result.
+      if (token !== this.refreshToken) return;
+
+      this.stats.set({
+        counts: {
+          'new-series': newSeries.elementCount,
+          'old-series': oldSeries.elementCount,
+          measurement: measurement.elementCount,
+        },
+        storageSizeMB,
+      });
+    } catch {
+      /* IndexedDB unavailable in this context */
+    }
+  }
+
+  private async estimateStorageMB(): Promise<number> {
+    try {
+      if ('storage' in navigator && 'estimate' in navigator.storage) {
+        const estimate = await navigator.storage.estimate();
+
+        return (estimate.usage ?? 0) / (1024 * 1024);
+      }
+    } catch {
+      /* unavailable in some contexts */
+    }
+
+    return 0;
+  }
+}

--- a/packages/index-db-cache/src/app/index-db-cache-action/services/measurement-cache.service.spec.ts
+++ b/packages/index-db-cache/src/app/index-db-cache-action/services/measurement-cache.service.spec.ts
@@ -1,3 +1,4 @@
+import { CacheEventsService } from './cache-events.service';
 import { MeasurementCacheService } from './measurement-cache.service';
 
 describe('MeasurementCacheService.computeGaps', () => {
@@ -8,7 +9,7 @@ describe('MeasurementCacheService.computeGaps', () => {
   const d = (s: string): Date => new Date(s);
 
   beforeEach(() => {
-    service = new MeasurementCacheService();
+    service = new MeasurementCacheService(new CacheEventsService());
   });
 
   it('returns the full range as one gap when coverage is empty', () => {

--- a/packages/index-db-cache/src/app/index-db-cache-action/services/measurement-cache.service.ts
+++ b/packages/index-db-cache/src/app/index-db-cache-action/services/measurement-cache.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { CumulocityMeasurement } from './chart-data.service';
+import { CacheEventsService } from './cache-events.service';
 import { COVERAGE_TTL_MS, asError } from './interceptor-helpers';
 
 // ─── DB constants ─────────────────────────────────────────────────────────────
@@ -69,6 +70,8 @@ interface CoverageRecord {
 export class MeasurementCacheService {
   private dbPromise: Promise<IDBDatabase> | null = null;
 
+  constructor(private readonly events: CacheEventsService) {}
+
   // ─── Cache reads ─────────────────────────────────────────────────────────────
 
   async getRange(
@@ -96,6 +99,10 @@ export class MeasurementCacheService {
           results.push(JSON.parse((cursor.value as MeasurementEntry).raw) as CumulocityMeasurement);
           cursor.continue();
         } else {
+          if (results.length) {
+            this.events.notifyRead();
+          }
+
           resolve(results);
         }
       };
@@ -226,6 +233,8 @@ export class MeasurementCacheService {
       tx.oncomplete = () => resolve();
       tx.onerror = () => reject(asError(tx.error, 'IndexedDB transaction failed'));
     });
+
+    this.events.notifyChanged();
   }
 
   // ─── Cache management ─────────────────────────────────────────────────────────
@@ -261,7 +270,10 @@ export class MeasurementCacheService {
         new Promise<void>((resolve, reject) => {
           const tx = db.transaction([STORE_DATA, STORE_COVERAGE], 'readwrite');
 
-          tx.oncomplete = () => resolve();
+          tx.oncomplete = () => {
+            this.events.notifyChanged();
+            resolve();
+          };
           tx.onerror = () => reject(asError(tx.error, 'IndexedDB transaction failed'));
           tx.objectStore(STORE_DATA).clear();
           tx.objectStore(STORE_COVERAGE).clear();
@@ -275,7 +287,10 @@ export class MeasurementCacheService {
         new Promise<void>((resolve, reject) => {
           const tx = db.transaction([STORE_DATA, STORE_COVERAGE], 'readwrite');
 
-          tx.oncomplete = () => resolve();
+          tx.oncomplete = () => {
+            this.events.notifyChanged();
+            resolve();
+          };
           tx.onerror = () => reject(asError(tx.error, 'IndexedDB transaction failed'));
 
           const dataStore = tx.objectStore(STORE_DATA);

--- a/packages/index-db-cache/src/app/index-db-cache-action/services/new-series-cache.service.ts
+++ b/packages/index-db-cache/src/app/index-db-cache-action/services/new-series-cache.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { AggregatedISeries } from './chart-data.service';
+import { CacheEventsService } from './cache-events.service';
 import { COVERAGE_TTL_MS, asError } from './interceptor-helpers';
 
 // ─── DB constants ────────────────────────────────────────────────────────────
@@ -73,6 +74,8 @@ interface CoverageRecord {
 export class NewSeriesCacheService {
   private dbPromise: Promise<IDBDatabase> | null = null;
 
+  constructor(private readonly events: CacheEventsService) {}
+
   // ─── Cache reads ─────────────────────────────────────────────────────────────
 
   /**
@@ -116,6 +119,10 @@ export class NewSeriesCacheService {
           ];
           cursor.continue();
         } else {
+          if (Object.keys(values).length) {
+            this.events.notifyRead();
+          }
+
           resolve({ values });
         }
       };
@@ -270,6 +277,8 @@ export class NewSeriesCacheService {
       tx.oncomplete = () => resolve();
       tx.onerror = () => reject(asError(tx.error, 'IndexedDB transaction failed'));
     });
+
+    this.events.notifyChanged();
   }
 
   // ─── Cache management ─────────────────────────────────────────────────────────
@@ -315,7 +324,10 @@ export class NewSeriesCacheService {
         new Promise<void>((resolve, reject) => {
           const tx = db.transaction([STORE_DATA, STORE_COVERAGE], 'readwrite');
 
-          tx.oncomplete = () => resolve();
+          tx.oncomplete = () => {
+            this.events.notifyChanged();
+            resolve();
+          };
           tx.onerror = () => reject(asError(tx.error, 'IndexedDB transaction failed'));
           tx.objectStore(STORE_DATA).clear();
           tx.objectStore(STORE_COVERAGE).clear();
@@ -331,7 +343,10 @@ export class NewSeriesCacheService {
         new Promise<void>((resolve, reject) => {
           const tx = db.transaction([STORE_DATA, STORE_COVERAGE], 'readwrite');
 
-          tx.oncomplete = () => resolve();
+          tx.oncomplete = () => {
+            this.events.notifyChanged();
+            resolve();
+          };
           tx.onerror = () => reject(asError(tx.error, 'IndexedDB transaction failed'));
 
           const dataStore = tx.objectStore(STORE_DATA);

--- a/packages/index-db-cache/src/app/index-db-cache-action/services/old-series-cache.service.ts
+++ b/packages/index-db-cache/src/app/index-db-cache-action/services/old-series-cache.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { AggregatedISeries } from './chart-data.service';
+import { CacheEventsService } from './cache-events.service';
 import { COVERAGE_TTL_MS, asError } from './interceptor-helpers';
 
 // ─── DB constants ─────────────────────────────────────────────────────────────
@@ -65,6 +66,8 @@ interface CoverageRecord {
 export class OldSeriesCacheService {
   private dbPromise: Promise<IDBDatabase> | null = null;
 
+  constructor(private readonly events: CacheEventsService) {}
+
   // ─── Cache reads ─────────────────────────────────────────────────────────────
 
   async getRange(
@@ -104,6 +107,10 @@ export class OldSeriesCacheService {
           ];
           cursor.continue();
         } else {
+          if (Object.keys(values).length) {
+            this.events.notifyRead();
+          }
+
           resolve({ values });
         }
       };
@@ -246,6 +253,8 @@ export class OldSeriesCacheService {
       tx.oncomplete = () => resolve();
       tx.onerror = () => reject(asError(tx.error, 'IndexedDB transaction failed'));
     });
+
+    this.events.notifyChanged();
   }
 
   // ─── Cache management ─────────────────────────────────────────────────────────
@@ -281,7 +290,10 @@ export class OldSeriesCacheService {
         new Promise<void>((resolve, reject) => {
           const tx = db.transaction([STORE_DATA, STORE_COVERAGE], 'readwrite');
 
-          tx.oncomplete = () => resolve();
+          tx.oncomplete = () => {
+            this.events.notifyChanged();
+            resolve();
+          };
           tx.onerror = () => reject(asError(tx.error, 'IndexedDB transaction failed'));
           tx.objectStore(STORE_DATA).clear();
           tx.objectStore(STORE_COVERAGE).clear();
@@ -297,7 +309,10 @@ export class OldSeriesCacheService {
         new Promise<void>((resolve, reject) => {
           const tx = db.transaction([STORE_DATA, STORE_COVERAGE], 'readwrite');
 
-          tx.oncomplete = () => resolve();
+          tx.oncomplete = () => {
+            this.events.notifyChanged();
+            resolve();
+          };
           tx.onerror = () => reject(asError(tx.error, 'IndexedDB transaction failed'));
 
           const dataStore = tx.objectStore(STORE_DATA);


### PR DESCRIPTION
Replace the manual refresh flow in the cache drawer with reactive state so
the UI reflects the caches as soon as an interceptor writes to them.

Add CacheEventsService, notified by the three cache services on every write,
clear and read. CacheStatsService recounts entries off the changed signal
(300ms debounce, stale-result guard) and owns clearAll(); the component
consumes it with OnPush and computed rows.

Drop the per-row "Est. Size" column, since navigator.storage.estimate() is
origin-wide and reported the same value for every cache — it is now shown
once as a global figure. Replace the per-row delete buttons with a single
"Clear all caches" action and remove the refresh button entirely.

Add a floppy-drive style LED to the toolbar button and drawer header that
blinks green when a read returns cached data, and swap the hardcoded hex
colors for c8y design tokens so the panel works in the dark theme.